### PR TITLE
Add Social Media Share Buttons to Quiz Results

### DIFF
--- a/frontend/src/components/ResultsSummary.jsx
+++ b/frontend/src/components/ResultsSummary.jsx
@@ -120,28 +120,90 @@ const ResultsSummary = ({ results, onRestart }) => {
         </div>
 
         {/* Action Buttons */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+        <div className="flex flex-col gap-6 justify-center">
           <button
             onClick={onRestart}
-            className="btn-primary text-lg px-8 py-4"
+            className="btn-primary text-lg px-8 py-4 mx-auto"
           >
             🔄 Try Again
           </button>
           
-          <button
-            onClick={() => {
-              const text = `I just scored ${score}/${total} (${percentage}%) on the 90s Fun Quiz! 🎉`;
-              if (navigator.share) {
-                navigator.share({ text });
-              } else {
-                navigator.clipboard.writeText(text);
-                alert('Score copied to clipboard!');
-              }
-            }}
-            className="btn-secondary text-lg px-8 py-4"
-          >
-            📤 Share Score
-          </button>
+          {/* Social Share Section */}
+          <div className="bg-gray-50 rounded-xl p-6">
+            <h4 className="text-lg font-semibold text-gray-800 text-center mb-4">
+              📤 Share Your Results
+            </h4>
+            
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              {/* Facebook Share */}
+              <button
+                onClick={() => {
+                  const shareText = `I just scored ${score}/${total} (${percentage}%) on the 90s Fun Quiz! 🎉 Can you beat my score?`;
+                  const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent(shareText)}`;
+                  window.open(facebookUrl, '_blank', 'width=600,height=400');
+                }}
+                className="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg transition-colors duration-200 text-sm font-medium"
+              >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                </svg>
+                Facebook
+              </button>
+
+              {/* Twitter Share */}
+              <button
+                onClick={() => {
+                  const shareText = `I just scored ${score}/${total} (${percentage}%) on the 90s Fun Quiz! 🎉 Can you beat my score?`;
+                  const hashtags = '90sQuiz,Quiz,90s,Challenge';
+                  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&hashtags=${encodeURIComponent(hashtags)}&url=${encodeURIComponent(window.location.href)}`;
+                  window.open(twitterUrl, '_blank', 'width=600,height=400');
+                }}
+                className="flex items-center justify-center gap-2 bg-black hover:bg-gray-800 text-white px-6 py-3 rounded-lg transition-colors duration-200 text-sm font-medium"
+              >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                </svg>
+                Twitter
+              </button>
+
+              {/* LinkedIn Share */}
+              <button
+                onClick={() => {
+                  const shareText = `I just scored ${score}/${total} (${percentage}%) on the 90s Fun Quiz! 🎉 Test your 90s knowledge and see if you can beat my score!`;
+                  const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(window.location.href)}&summary=${encodeURIComponent(shareText)}`;
+                  window.open(linkedinUrl, '_blank', 'width=600,height=400');
+                }}
+                className="flex items-center justify-center gap-2 bg-blue-700 hover:bg-blue-800 text-white px-6 py-3 rounded-lg transition-colors duration-200 text-sm font-medium"
+              >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+                </svg>
+                LinkedIn
+              </button>
+            </div>
+
+            {/* Fallback Copy Button */}
+            <div className="mt-4 text-center">
+              <button
+                onClick={() => {
+                  const text = `I just scored ${score}/${total} (${percentage}%) on the 90s Fun Quiz! 🎉`;
+                  if (navigator.share) {
+                    navigator.share({ 
+                      title: '90s Fun Quiz Results',
+                      text: text,
+                      url: window.location.href
+                    });
+                  } else {
+                    navigator.clipboard.writeText(`${text} ${window.location.href}`);
+                    alert('Score and link copied to clipboard!');
+                  }
+                }}
+                className="text-gray-600 hover:text-gray-800 text-sm underline transition-colors duration-200"
+              >
+                � Copy to Clipboard
+              </button>
+            </div>
+          </div>
         </div>
 
         {/* Fun Stats */}


### PR DESCRIPTION
## Description
This PR implements the social sharing feature requested in issue #130, allowing users to share their quiz results directly to Facebook, Twitter, and LinkedIn.

## Changes Made
- **Enhanced Results Sharing**: Replaced the basic "Share Score" button with dedicated social media share buttons
- **Facebook Integration**: Share results with a custom message and quiz URL
- **Twitter Integration**: Share results with relevant hashtags (#90sQuiz, #Quiz, #90s, #Challenge) 
- **LinkedIn Integration**: Share results with professional-friendly messaging
- **Improved UI**: Added a dedicated share section with better styling and icons
- **Fallback Support**: Maintained copy-to-clipboard functionality for unsupported browsers

## Technical Details
- Uses platform-specific share URLs with proper encoding
- Opens share dialogs in new windows with optimal dimensions (600x400)
- Includes quiz score, percentage, and encouraging challenge message
- Responsive design that works on both desktop and mobile
- SVG icons for each social platform

## Testing
- ✅ Share buttons open correct social media sharing dialogs
- ✅ Shared messages include quiz results and scores
- ✅ URLs are properly encoded
- ✅ Fallback clipboard functionality works
- ✅ Responsive design maintained
- ✅ No ESLint errors

## Screenshots
The new share section appears below the "Try Again" button with three prominent social media share buttons and a fallback copy option.

Closes #130